### PR TITLE
Fix NeoForge shader crash with Iris/other shader mods

### DIFF
--- a/src/main/java/com/corosus/watut/ShaderInstanceBlur.java
+++ b/src/main/java/com/corosus/watut/ShaderInstanceBlur.java
@@ -17,7 +17,7 @@ public class ShaderInstanceBlur extends ShaderInstance {
     public final Uniform BLUR_LEVEL;
 
     public ShaderInstanceBlur(ResourceProvider p_173336_, ResourceLocation shaderLocation, VertexFormat p_173338_) throws IOException {
-        super(p_173336_, shaderLocation.toString(), p_173338_);
+        super(p_173336_, shaderLocation, p_173338_);
         this.RESOLUTION = this.getUniform("resolution");
         this.RADIUS = this.getUniform("radius");
         this.BLUR_LEVEL = this.getUniform("blurLevel");

--- a/src/main/java/com/corosus/watut/loader/neoforge/ClientEvents.java
+++ b/src/main/java/com/corosus/watut/loader/neoforge/ClientEvents.java
@@ -1,14 +1,48 @@
 package com.corosus.watut.loader.neoforge;
 
 import com.corosus.watut.ParticleRegistry;
+import com.corosus.watut.PlayerStatusManagerClient;
+import com.corosus.watut.ShaderInstanceBlur;
 import com.corosus.watut.WatutMod;
 import com.corosus.watut.command.CommandWatutReloadJSON;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import net.minecraft.resources.ResourceLocation;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.InputEvent;
 import net.neoforged.neoforge.client.event.RegisterClientCommandsEvent;
+import net.neoforged.neoforge.client.event.RegisterShadersEvent;
 import net.neoforged.neoforge.client.event.TextureAtlasStitchedEvent;
 
+import java.io.IOException;
+
 public class ClientEvents {
+
+    public void onRegisterShaders(RegisterShadersEvent event) {
+        try {
+            event.registerShader(
+                    new ShaderInstanceBlur(event.getResourceProvider(),
+                            ResourceLocation.fromNamespaceAndPath(WatutMod.MODID, "particle"),
+                            DefaultVertexFormat.PARTICLE),
+                    s -> PlayerStatusManagerClient.particle = (ShaderInstanceBlur) s);
+            event.registerShader(
+                    new ShaderInstanceBlur(event.getResourceProvider(),
+                            ResourceLocation.fromNamespaceAndPath(WatutMod.MODID, "position_tex_blur"),
+                            DefaultVertexFormat.POSITION_TEX),
+                    s -> PlayerStatusManagerClient.positionTexBlur = (ShaderInstanceBlur) s);
+            event.registerShader(
+                    new ShaderInstanceBlur(event.getResourceProvider(),
+                            ResourceLocation.fromNamespaceAndPath(WatutMod.MODID, "position_tex_blur_horizontal"),
+                            DefaultVertexFormat.POSITION_TEX),
+                    s -> PlayerStatusManagerClient.positionTexBlurHorizontal = (ShaderInstanceBlur) s);
+            event.registerShader(
+                    new ShaderInstanceBlur(event.getResourceProvider(),
+                            ResourceLocation.fromNamespaceAndPath(WatutMod.MODID, "position_tex_blur_vertical"),
+                            DefaultVertexFormat.POSITION_TEX),
+                    s -> PlayerStatusManagerClient.positionTexBlurVertical = (ShaderInstanceBlur) s);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     public void getRegisteredParticles(TextureAtlasStitchedEvent event) {
         ParticleRegistry.textureAtlasUpload(event.getAtlas());

--- a/src/main/java/com/corosus/watut/loader/neoforge/WatutModNeoForge.java
+++ b/src/main/java/com/corosus/watut/loader/neoforge/WatutModNeoForge.java
@@ -31,6 +31,7 @@ public class WatutModNeoForge extends WatutMod {
         if (FMLEnvironment.dist.isClient()) {
             ClientEvents clientEvents = new ClientEvents();
             container.getEventBus().addListener(clientEvents::getRegisteredParticles);
+            container.getEventBus().addListener(clientEvents::onRegisterShaders);
             NeoForge.EVENT_BUS.addListener(clientEvents::onRegisterCommandsClient);
             NeoForge.EVENT_BUS.addListener(clientEvents::onGameTick);
             NeoForge.EVENT_BUS.addListener(clientEvents::onKey);

--- a/src/main/resources/watut.mixins.json
+++ b/src/main/resources/watut.mixins.json
@@ -10,7 +10,6 @@
     "client.ScreenRenderBackground",
     "client.ScreenRenderWithTooltip",
     "client.PostChainResize",
-    "client.GameRendererReloadShaders",
     "client.ParticleEngineMixin",
     "client.NativeImageAccessor"
   ],


### PR DESCRIPTION
## Summary
- Replace `GameRendererReloadShaders` mixin with `RegisterShadersEvent` for shader registration on NeoForge
- Fix `ShaderInstanceBlur` to use NeoForge's `ResourceLocation` super constructor directly
- Remove unused mixin entry from `watut.mixins.json`

## Problem
On NeoForge 1.21.1, the game crashes on startup with:
```
FileNotFoundException: minecraft:shaders/core/particle.json
```
The `GameRendererReloadShaders` mixin injects at the end of `reloadShaders`, but the `ResourceProvider` passed to that method does not include mod resources. The custom `getResourceFactory` wrapper attempts to redirect lookups from `minecraft:` to `watut:` namespace, but neither the provider nor the global resource manager can resolve `watut:` resources at that point.

## Fix
Use NeoForge's `RegisterShadersEvent` instead of a mixin. This is the standard approach used by other mods that ship custom shaders (Create, Mekanism, Alex's Caves, Twilight Forest, etc.). The event provides a `ResourceProvider` that includes all mod resources, so shaders under `assets/watut/shaders/core/` are found correctly.

## Testing
Tested with a 219-mod NeoForge 1.21.1 modpack including Iris, Sodium, and many mods with GameRenderer mixins. Game launches and loads successfully.

🤖 Generated with [Claude Code](https://claude.ai/code)