### PR TITLE
Make NeoForge client optional

### DIFF
--- a/src/main/java/com/corosus/watut/loader/neoforge/WatutModNeoForge.java
+++ b/src/main/java/com/corosus/watut/loader/neoforge/WatutModNeoForge.java
@@ -44,7 +44,7 @@ public class WatutModNeoForge extends WatutMod {
     }
 
     public void registerPackets(final RegisterPayloadHandlersEvent event) {
-        final PayloadRegistrar registrar = event.registrar("1.0.0");
+        final PayloadRegistrar registrar = event.registrar("1.0.0").optional();
         WatutNetworkingNeoForge.register(registrar);
     }
 

--- a/src/main/java/com/corosus/watut/loader/neoforge/WatutNetworkingNeoForge.java
+++ b/src/main/java/com/corosus/watut/loader/neoforge/WatutNetworkingNeoForge.java
@@ -1,6 +1,7 @@
 package com.corosus.watut.loader.neoforge;
 
 import com.corosus.coroutil.util.CULog;
+import com.corosus.watut.WatutMod;
 import com.corosus.watut.WatutModClient;
 import com.corosus.watut.WatutNetworking;
 import com.corosus.watut.network.*;
@@ -11,11 +12,13 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.players.PlayerList;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.network.PacketDistributor;
 import net.neoforged.neoforge.network.handling.IPayloadHandler;
+import net.neoforged.neoforge.network.registration.NetworkRegistry;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
 
 import java.util.function.BiConsumer;
@@ -83,17 +86,30 @@ public class WatutNetworkingNeoForge extends WatutNetworking {
 
     @Override
     public void serverSendToClientAll(CompoundTag data) {
-        PacketDistributor.sendToAllPlayers(new PacketNBTFromServer(data));
+        PlayerList playerList = WatutMod.instance().getPlayerList();
+        if (playerList == null) return;
+        for (ServerPlayer player : playerList.getPlayers()) {
+            serverSendToClientPlayer(data, player);
+        }
     }
 
     @Override
     public void serverSendToClientPlayer(CompoundTag data, Player player) {
-        PacketDistributor.sendToPlayer((ServerPlayer) player, new PacketNBTFromServer(data));
+        ServerPlayer serverPlayer = (ServerPlayer) player;
+        if (NetworkRegistry.hasChannel(serverPlayer.connection, PacketNBTFromServer.TYPE.id())) {
+            PacketDistributor.sendToPlayer(serverPlayer, new PacketNBTFromServer(data));
+        }
     }
 
     @Override
     public void serverSendToClientNear(CompoundTag data, Vec3 pos, double dist, Level level) {
-        PacketDistributor.sendToPlayersNear((ServerLevel) level, null, pos.x, pos.y, pos.z, dist, new PacketNBTFromServer(data));
+        ServerLevel serverLevel = (ServerLevel) level;
+        double distSqr = dist * dist;
+        for (ServerPlayer player : serverLevel.players()) {
+            if (player.distanceToSqr(pos) <= distSqr) {
+                serverSendToClientPlayer(data, player);
+            }
+        }
     }
 }
 

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -43,6 +43,9 @@ displayName="${mod_name}" #mandatory
 # A text field displayed in the mod UI
 authors="${mod_authors}" #optional
 
+# Allow servers to run WATUT without requiring clients to install it.
+displayTest="IGNORE_SERVER_VERSION" #optional
+
 # The description text for the mod (multi line!) (#mandatory)
 description='''${mod_description}'''
 


### PR DESCRIPTION
## Summary

Makes the NeoForge build of WATUT optional on clients when installed on a server.

## Details

This updates the NeoForge mod metadata with `displayTest="IGNORE_SERVER_VERSION"` so clients are not rejected only because the server has WATUT installed.

It also registers WATUT's NeoForge payloads as optional and guards server-to-client packet sends with `NetworkRegistry.hasChannel(...)`, so servers do not send WATUT payloads to clients that did not negotiate the WATUT channel.

## Why

Without this, a server with WATUT installed rejects clients that do not have WATUT installed. After adding only the display test, connection still fails during payload negotiation because `watut:nbt_server` and `watut:nbt_client` are treated as required channels.
